### PR TITLE
Removed multiply_els from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,4 @@ The following table has the methods you will need to implement along with their 
 | `Enumerable#my_none?`           | spec/my_none_spec.rb            |                                                                       |
 | `Enumerable#my_count`           | spec/my_count_spec.rb           |                                                                       |
 | `Enumerable#my_map`             | spec/my_map_spec.rb             |                                                                       |
-| `Enumerable#my_inject`          | spec/my_inject_spec.rb          |                                                                       |
-| `multiply_els`                  | spec/multiply_els_spec.rb       | You will need to complete this function in `lib/multiply_els.rb`      |
+| `Enumerable#my_inject`          | spec/my_inject_spec.rb              


### PR DESCRIPTION
That exercise seems to have been removed from the lib and tests. I removed it from the readme too.