### PR TITLE
Spec Files: Add examples for checking `Enumerator` returns

### DIFF
--- a/spec/my_each_spec.rb
+++ b/spec/my_each_spec.rb
@@ -31,5 +31,15 @@ RSpec.describe Array do
         expect(my_each_results).to eq(each_results)
       end
     end
+
+    context 'when not given a block' do
+      it 'returns an Enumerator' do
+        expect(array.my_each).to be_a Enumerator
+      end
+
+      it 'contains the elements of the receiving array' do
+        expect(array.my_each.to_a).to eq array
+      end
+    end
   end
 end

--- a/spec/my_each_with_index_spec.rb
+++ b/spec/my_each_with_index_spec.rb
@@ -31,5 +31,19 @@ RSpec.describe Enumerable do
         expect(my_each_with_index_results).to eq(each_with_index_results)
       end
     end
+
+    context 'when not given a block' do
+      it 'returns an Enumerator' do
+        expect(enumerable.my_each_with_index).to be_a Enumerator
+      end
+
+      it 'contains the elements and indices of the receiving array' do
+        expect(enumerable.my_each_with_index.to_a).to eq(
+          [[1, 0], [1, 1], [2, 2],
+          [3, 3], [5, 4], [8, 5],
+          [13, 6], [21, 7], [34, 8]]
+        )
+      end
+    end
   end
 end

--- a/spec/my_map_spec.rb
+++ b/spec/my_map_spec.rb
@@ -21,5 +21,15 @@ RSpec.describe Enumerable do
         expect(enumerable.my_map(&:odd?)).to eq([true, true, false, true, true, false, true, true, false])
       end
     end
+
+    context 'when not given a block' do
+      it 'returns an Enumerator' do
+        expect(enumerable.my_map).to be_a Enumerator
+      end
+
+      it 'contains the elements of the receiving array' do
+        expect(enumerable.my_map.to_a).to eq enumerable
+      end
+    end
   end
 end

--- a/spec/my_select_spec.rb
+++ b/spec/my_select_spec.rb
@@ -6,17 +6,27 @@ RSpec.describe Enumerable do
   subject(:enumerable) { [1, 1, 2, 3, 5, 8, 13, 21, 34] }
 
   describe '#my_select' do
-    it 'returns only the values that match the condition' do
-      expect(enumerable.my_select { |value| value > 10 }).to eq([13, 21, 34])
-    end
+    context 'when given a block' do
+      it 'returns only the values that match the condition' do
+        expect(enumerable.my_select { |value| value > 10 }).to eq([13, 21, 34])
+      end
 
-    it 'filters values that do not match the condition' do
-      expect(enumerable.my_select { |value| value > 10 }).not_to include(1, 2, 3, 5, 8)
-    end
+      it 'filters values that do not match the condition' do
+        expect(enumerable.my_select { |value| value > 10 }).not_to include(1, 2, 3, 5, 8)
+      end
 
-    context 'when no items match the condition' do
-      it 'returns an empty array' do
+      it 'returns an empty array when no items match the condition' do
         expect(enumerable.my_select { |value| value > 40 }).to eq([])
+      end
+    end
+
+    context 'when not given a block' do
+      it 'returns an Enumerator' do
+        expect(enumerable.my_select).to be_a Enumerator
+      end
+
+      it 'contains the elements of the receiving array' do
+        expect(enumerable.my_select.to_a).to eq enumerable
       end
     end
   end


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
These methods actually return `Enumerator`s when a block isn't passed in. I think this behavior is completely fine and understandable to implement and will have learners working more with `block_given?`. See also: the curriculum PR that adds an explanation for Enumerators for more information about why I want it in: https://github.com/TheOdinProject/curriculum/pull/30649

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds test cases to check for the correct `Enumerator` returns on the following methods:
  - `#my_each`
  - `#my_each_with_index`
  - `#my_map`
  - `#my_select`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `Intro to HTML and CSS lesson: Fix link text`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
